### PR TITLE
Use object as arg for dataset context constructor for a poor mans kwargs

### DIFF
--- a/bids-validator/src/schema/context.ts
+++ b/bids-validator/src/schema/context.ts
@@ -33,26 +33,19 @@ export class BIDSContextDataset implements ContextDataset {
   schema: Schema
 
   constructor(
-    options?: ValidatorOptions,
-    schema?: Schema,
-    tree?: FileTree,
-    description?: Record<string, unknown>,
-    ignored?: BIDSFile[],
-    datatypes?: string[],
-    modalities?: string[],
-    issues?: DatasetIssues,
+    args: Partial<BIDSContextDataset>
   ) {
-    this.schema = schema || {} as unknown as Schema
-    this.dataset_description = description || {}
-    this.tree = tree || new FileTree('/unknown', 'unknown')
-    this.ignored = ignored || []
-    this.datatypes = datatypes || []
-    this.modalities = modalities || []
+    this.schema = args.schema || {} as unknown as Schema
+    this.dataset_description = args.dataset_description || {}
+    this.tree = args.tree || new FileTree('/unknown', 'unknown')
+    this.ignored = args.ignored || []
+    this.datatypes = args.datatypes || []
+    this.modalities = args.modalities || []
     this.sidecarKeyValidated = new Set<string>()
-    if (options) {
-      this.options = options
+    if (args.options) {
+      this.options = args.options
     }
-    this.issues = issues || new DatasetIssues()
+    this.issues = args.issues || new DatasetIssues()
   }
 
   get dataset_description(): Record<string, unknown> {
@@ -118,7 +111,7 @@ export class BIDSContext implements Context {
     this.suffix = bidsEntities.suffix
     this.extension = bidsEntities.extension
     this.entities = bidsEntities.entities
-    this.dataset = dsContext ? dsContext : new BIDSContextDataset(undefined, undefined, fileTree)
+    this.dataset = dsContext ? dsContext : new BIDSContextDataset({tree: fileTree})
     this.subject = {} as ContextSubject
     this.datatype = ''
     this.modality = ''

--- a/bids-validator/src/schema/walk.test.ts
+++ b/bids-validator/src/schema/walk.test.ts
@@ -6,7 +6,7 @@ import { simpleDataset, simpleDatasetFileCount } from '../tests/simple-dataset.t
 
 Deno.test('file tree walking', async (t) => {
   await t.step('visits each file and creates a BIDSContext', async () => {
-    const dsContext = new BIDSContextDataset(undefined, undefined, simpleDataset)
+    const dsContext = new BIDSContextDataset({tree: simpleDataset})
     for await (const context of walkFileTree(dsContext)) {
       assert(
         context instanceof BIDSContext,
@@ -15,7 +15,7 @@ Deno.test('file tree walking', async (t) => {
     }
   })
   await t.step('visits every file expected', async () => {
-    const dsContext = new BIDSContextDataset(undefined, undefined, simpleDataset)
+    const dsContext = new BIDSContextDataset({tree: simpleDataset})
     let accumulator = 0
     for await (const context of walkFileTree(dsContext)) {
       assert(

--- a/bids-validator/src/tests/local/hed-integration.test.ts
+++ b/bids-validator/src/tests/local/hed-integration.test.ts
@@ -30,9 +30,9 @@ Deno.test('hed-validator not triggered', async (t) => {
   const PATH = 'tests/data/bids-examples/ds003'
   const tree = await readFileTree(PATH)
   const schema = await loadSchema()
-  const dsContext = new BIDSContextDataset(undefined, undefined, undefined, {
+  const dsContext = new BIDSContextDataset({dataset_description: {
     'HEDVersion': ['bad_version'],
-  })
+  }})
   await t.step('detect hed returns false', async () => {
     const eventFile = getFile(tree, 'sub-01/func/sub-01_task-rhymejudgment_events.tsv')
     assert(eventFile !== undefined)
@@ -48,9 +48,9 @@ Deno.test('hed-validator fails with bad schema version', async (t) => {
   const PATH = 'tests/data/bids-examples/eeg_ds003645s_hed_library'
   const tree = await readFileTree(PATH)
   const schema = await loadSchema()
-  const dsContext = new BIDSContextDataset(undefined, undefined, undefined, {
+  const dsContext = new BIDSContextDataset({dataset_description: {
     'HEDVersion': ['bad_version'],
-  })
+  }})
   await t.step('detect hed returns false', async () => {
     const eventFile = getFile(tree, 'sub-002/eeg/sub-002_task-FacePerception_run-3_events.tsv')
     assert(eventFile !== undefined)

--- a/bids-validator/src/validators/bids.ts
+++ b/bids-validator/src/validators/bids.ts
@@ -48,7 +48,7 @@ export async function validate(
     (file: BIDSFile) => file.name === 'dataset_description.json',
   )
 
-  const dsContext = new BIDSContextDataset(options, schema, fileTree)
+  const dsContext = new BIDSContextDataset({options, schema, tree: fileTree})
   if (ddFile) {
     dsContext.dataset_description = await loadJSON(ddFile).catch((error) => {
       dsContext.issues.addNonSchemaIssue(error.key, [ddFile])


### PR DESCRIPTION
Makes the `new BIDSContextDataset` calls a bit more explicit while simplifying constructor typing.